### PR TITLE
fix: add mypy, typecheck, and tests to pre-commit hook

### DIFF
--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -23,7 +23,7 @@ async def upload_cookies(request: CookieUploadRequest) -> CookieStatus:
 
 
 @router.delete("/cookies")
-async def delete_cookies() -> dict:
+async def delete_cookies() -> dict[str, str]:
     """Delete all stored cookies."""
     await _cookie_manager.delete_cookies()
     return {"message": "Cookieを削除しました"}

--- a/backend/app/automation/amazon_fresh.py
+++ b/backend/app/automation/amazon_fresh.py
@@ -248,17 +248,17 @@ class AmazonFreshAutomator:
 
         if strategy == "cheapest":
             if priced:
-                return min(priced, key=lambda c: c.price)  # type: ignore[return-value]
+                return min(priced, key=lambda c: c.price or 0)
             return unpriced[0] if unpriced else None
 
         elif strategy == "premium":
             if priced:
-                return max(priced, key=lambda c: c.price)  # type: ignore[return-value]
+                return max(priced, key=lambda c: c.price or 0)
             return unpriced[0] if unpriced else None
 
         else:  # value: pick middle
             if priced:
-                sorted_priced = sorted(priced, key=lambda c: c.price)  # type: ignore[arg-type]
+                sorted_priced = sorted(priced, key=lambda c: c.price or 0)
                 mid = len(sorted_priced) // 2
                 return sorted_priced[mid]
             return unpriced[0] if unpriced else None

--- a/backend/app/automation/browser.py
+++ b/backend/app/automation/browser.py
@@ -52,7 +52,9 @@ class BrowserFactory:
                 )
 
                 if cookies:
-                    await context.add_cookies([self._to_playwright_cookie(c) for c in cookies])
+                    await context.add_cookies(
+                        [self._to_playwright_cookie(c) for c in cookies]  # type: ignore[misc]
+                    )
 
                 try:
                     yield context
@@ -83,8 +85,8 @@ class BrowserFactory:
                 await page.close()
 
     @staticmethod
-    def _to_playwright_cookie(cookie: CookieEntry) -> dict:
-        result: dict = {
+    def _to_playwright_cookie(cookie: CookieEntry) -> dict[str, object]:
+        result: dict[str, object] = {
             "name": cookie.name,
             "value": cookie.value,
             "domain": cookie.domain,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,7 @@ database initialization on startup.
 
 import logging
 import sys
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request, Response
@@ -110,7 +110,10 @@ app.include_router(api_router)
 
 
 @app.middleware("http")
-async def add_security_headers(request: Request, call_next) -> Response:  # type: ignore[type-arg]
+async def add_security_headers(
+    request: Request,  # noqa: ARG001
+    call_next: Callable[..., Awaitable[Response]],
+) -> Response:
     """Add security headers to all responses."""
     response = await call_next(request)
     response.headers["X-Content-Type-Options"] = "nosniff"
@@ -121,7 +124,7 @@ async def add_security_headers(request: Request, call_next) -> Response:  # type
 
 
 @app.get("/health")
-async def health() -> dict:
+async def health() -> dict[str, str]:
     """Returns a simple health check response.
 
     Returns:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -52,3 +52,9 @@ markers = [
 python_version = "3.12"
 strict = true
 ignore_missing_imports = true
+plugins = ["pydantic.mypy"]
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true


### PR DESCRIPTION
## Summary
- Add pydantic.mypy plugin and fix all 29 mypy strict errors
- Update pre-commit hook: 4 checks → 7 checks (ruff check, ruff format, mypy, pytest, eslint, tsc, vitest)
- Fix type annotations across backend (browser.py, main.py, settings.py, amazon_fresh.py)

Closes #1, Closes #2

## Test plan
- [x] `uv run mypy app/` passes (0 errors)
- [x] `uv run pytest -m "not integration"` passes (40 tests)
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (13 tests)
- [x] Pre-commit hook runs all 7 checks successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)