### PR TITLE
chore: add .env.example referenced by README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Required
+OPENAI_API_KEY=sk-your-openai-api-key
+
+# Optional — defaults shown
+# DATA_DIR=./data
+# DATABASE_PATH=./data/shopping.db
+# RULES_PATH=./data/rules.yaml
+# COOKIES_PATH=./data/cookies.json
+# CONFIG_DIR=./config
+# BROWSER_HEADLESS=true
+# LOG_LEVEL=INFO
+
+# API authentication (empty = no auth)
+# API_SECRET_KEY=


### PR DESCRIPTION
## Summary
- Add `.env.example` with all environment variables documented in CLAUDE.md
- README references `cp .env.example .env` but the file didn't exist

## Test plan
- [x] File contains all variables from CLAUDE.md Environment Variables table
- [x] Secrets use placeholder values, not real keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)