### PR TITLE
fix: use relative paths for default data directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Runs on push to `main` and all PRs. Mirrors pre-commit checks plus `npm run buil
 | Variable | Description |
 |---|---|
 | `OPENAI_API_KEY` | OpenAI API key |
-| `DATA_DIR` | Data directory path (default: `/data`) |
+| `DATA_DIR` | Data directory path (default: `./data`, Docker: `/data`) |
 | `DATABASE_PATH` | SQLite DB path |
 | `RULES_PATH` | Shopping rules YAML path |
 | `COOKIES_PATH` | Amazon cookies JSON path |

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -23,12 +23,12 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
     openai_api_key: str = ""
-    data_dir: Path = Path("/data")
-    config_dir: Path = Path("/config")
-    database_path: Path = Path("/data/shopping.db")
-    rules_path: Path = Path("/data/rules.yaml")
-    cookies_path: Path = Path("/data/cookies.json")
-    profile_path: Path = Path("/data/profile.json")
+    data_dir: Path = Path("./data")
+    config_dir: Path = Path("./config")
+    database_path: Path = Path("./data/shopping.db")
+    rules_path: Path = Path("./data/rules.yaml")
+    cookies_path: Path = Path("./data/cookies.json")
+    profile_path: Path = Path("./data/profile.json")
 
     # OpenAI model
     openai_model: str = "gpt-5.4-mini"


### PR DESCRIPTION
## Summary
- Changed default paths in `backend/app/config.py` from absolute `/data` to relative `./data`
- Fixes startup crash on local development (read-only filesystem error)
- Updated `CLAUDE.md` environment variables table

Closes #11

## Test plan
- [x] `uv run uvicorn app.main:app --reload --port 8000` starts without error
- [x] All 40 backend tests pass
- [x] All 13 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)